### PR TITLE
fixed requirements info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ print this or take a picture directly from the document (or just download the pi
 
 https://docs.google.com/document/d/1IEYuL2panN8EVcPyZixLzO42TQxTmX7FqdUAkxwV4vk/edit?usp=sharing
 
-install required python packages through **pip install requirements.txt**
-
+install required python packages through `pip install -r requirements.txt`
+64-bit Python required
+Microsoft Visual C++ 14.0 or greater required https://visualstudio.microsoft.com/visual-cpp-build-tools/
 
 ## Usage
 
@@ -22,4 +23,3 @@ $ to run this file do chmod +x keyfile.kdb
 $ finally type in ./keyfile.kdb 
 $ u have officially ran minecraft from a piece of paper :D
 ```
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 pyzbar
 argparse
-cv2
-math
+opencv-python
 imutils
 numpy 
-skimage
-os
+scikit-image


### PR DESCRIPTION
64 bit python required for the latest versions of scipy https://stackoverflow.com/questions/73858491/cannot-install-scipy-using-pip
and Microsoft Visual C++ 14.0 or greater required for scikit-image (error: Microsoft Visual C++ 14.0 or greater is required)

Check if I put the right packages in requirements.txt pls (changed to actual pip packages and removed standard library packages), I still wasn't able to get it running due to `error: Microsoft Visual C++ 14.0 or greater is required` but this is closer to the proper setup instructions.